### PR TITLE
Fix blog post hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Remote storage adapter enabling Prometheus to use PostgreSQL as a long-term store for time-series metrics. Code is based on [Prometheus - Remote storage adapter](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter).
 
-The PostgreSQL Prometheus Adapter is designed to utilize native partitioning enhancements available in recent versions of core Postgres to efficiently store Prometheus time series data in a PostgreSQL database, and is not dependent on external PostgreSQL extensions. 
+The PostgreSQL Prometheus Adapter is designed to utilize native partitioning enhancements available in recent versions of core Postgres to efficiently store Prometheus time series data in a PostgreSQL database, and is not dependent on external PostgreSQL extensions.
 
 The design is based on partitioning and threads. Incoming data is processed by one or more threads and one or more writer threads will store data in PostgreSQL daily or hourly partitions. Partitions will be auto-created by the adapter based on the timestamp of incoming data.
 
-The PostgreSQL Prometheus Adapter accepts Prometheus remote read/write requests, and sends them to PostgreSQL. 
+The PostgreSQL Prometheus Adapter accepts Prometheus remote read/write requests, and sends them to PostgreSQL.
 
-Additional information regarding the adapter and getting started is provided below and available in this [blog post introducing the Postgres Prometheus Adapter]  (https://info.crunchydata.com/blog/using-postgres-to-back-prometheus-for-your-postgresql-monitoring-1).
+Additional information regarding the adapter and getting started is provided below and available in this [blog post introducing the Postgres Prometheus Adapter](https://info.crunchydata.com/blog/using-postgres-to-back-prometheus-for-your-postgresql-monitoring-1).
 
 ## PostgreSQL Version Support
 
@@ -130,7 +130,7 @@ remote_read:
 
 ## Maintainers
 
-The PostgreSQL Prometheus Adapter is maintained by the team at [Crunchy Data](https://www.crunchydata.com/). 
+The PostgreSQL Prometheus Adapter is maintained by the team at [Crunchy Data](https://www.crunchydata.com/).
 
 ## Contributing to the Project
 
@@ -138,5 +138,4 @@ Want to contribute to the PostgreSQL Prometheus Adapter? Great! Please use GitHu
 
 ## License
 
-The PostgreSQL Prometheus Adapter is available under the Apache 2.0 license. See [LICENSE](https://github.com/CrunchyData/postgresql-prometheus-adapter/blob/master/LICENSE) for details. 
-
+The PostgreSQL Prometheus Adapter is available under the Apache 2.0 license. See [LICENSE](https://github.com/CrunchyData/postgresql-prometheus-adapter/blob/master/LICENSE) for details.


### PR DESCRIPTION
Updates the README, fixing the hyperlink to the blog post announcing the adapter to render properly. Also removes a couple of extraneous whitespaces.